### PR TITLE
Remove activesupport. Closes #3

### DIFF
--- a/lib/scrum_yo/activity.rb
+++ b/lib/scrum_yo/activity.rb
@@ -22,7 +22,8 @@ module ScrumYo
     end
 
     def older_than_one_day(event)
-      (DateTime.now.in_time_zone('UTC') - event.created_at) / 1.hour > 24
+      # 3600 = seconds in an hour
+      (DateTime.now.in_time_zone('UTC') - event.created_at) / 3600 > 24
     end
 
     def filter_activity(events)

--- a/lib/scrum_yo/version.rb
+++ b/lib/scrum_yo/version.rb
@@ -1,3 +1,3 @@
 module ScrumYo
-  VERSION = "0.1.2"
+  VERSION = '0.1.3'
 end

--- a/scrum_yo.gemspec
+++ b/scrum_yo.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'octokit', '~> 2.0'
   spec.add_dependency 'netrc', '~> 0.7.7'
-  spec.add_dependency 'activesupport', '~> 4.1.0'
   spec.add_dependency 'colorize'
   spec.add_dependency 'highline'
 


### PR DESCRIPTION
Only being used for .hours. Reduce dependencies.
